### PR TITLE
2.5.5

### DIFF
--- a/Map Data/w3t.json
+++ b/Map Data/w3t.json
@@ -31970,7 +31970,7 @@
         },
         {
           "Key": "utub",
-          "Value": "[|cffd2d2d2Light|r]|nA holy light that can heal the Hero, a friendly living unit or deal half in |cffff00ffmagic damage|r to an enemy unit.|n|nWhen cast on a friendly unit one random negative buff is purged from it.|n|n|cffffff00Ability level bonus|r|nHeal/damage amount|n|n|cffff00ffHeal at level 30|r: 46600|n|cffd45e3aRange at level 30|r: 700|n|cffd49696Cooldown at level 30|r: 5 seconds|n"
+          "Value": "[|cffd2d2d2Light|r]|nA holy light that can heal the Hero, a friendly living unit or deal half in |cffff00ffmagic damage|r to an enemy unit.|n|nWhen cast on a friendly unit one random negative buff is purged from it.|n|n|cffffff00Ability level bonus|r|nHeal/damage amount|n|n|cffff00ffHeal at level 30|r: 35000|n|cffd45e3aRange at level 30|r: 700|n|cffd49696Cooldown at level 30|r: 8 seconds|n"
         },
         {
           "Key": "ides",
@@ -32656,7 +32656,7 @@
         },
         {
           "Key": "utub",
-          "Value": "When dealing |cffff8080physical damage|r, there is a chance to deal bonus |cffff00ffmagic damage|r based on the Hero's strength, as well as stun the target for 0.2 seconds.|n|n|cffffff00Ability level bonus|r|nBash chance, damage bonus|n|n|cff80ff80Chance at level 30|r: 30%|n|cffff00ffDamage at level 30|r: 3000 + 125% strength|n|n[|cff80ff80Luck|r]"
+          "Value": "When dealing |cffff8080physical damage|r, there is a chance to deal bonus |cffff00ffmagic damage|r based on the Hero's strength, as well as stun the target for 0.2 seconds.|n|n|cffffff00Ability level bonus|r|nBash chance, damage bonus|n|n|cff80ff80Chance at level 30|r: 30%|n|cffff00ffDamage at level 30|r: 3000 + 125% strength|n|n[|cffd45e29onhit|r][|cff80ff80Luck|r]"
         },
         {
           "Key": "ides",
@@ -39238,7 +39238,7 @@
         },
         {
           "Key": "utub",
-          "Value": "[|cffd45e19Earth|r]|nWhen dealing |cffff8080physical damage|r, gives the Hero a 20% chance to deal |cffff00ffmagic damage|r to enemies in a small area around the enemy.|n|n|cffc0c0c0Damage increases from hero block|r|r|n|n|cffffff00Ability level bonus|r|nDamage bonus|n|n|cffff00ffDamage at level 30|r: 3000 + 50% of the hero's block|n|cffd45e3aArea of effect at level 30|r: 300|n|n[|cff80ff80Luck|r][|cffd45e29onhit|r]"
+          "Value": "[|cffd45e19Earth|r]|nWhen dealing |cffff8080physical damage|r, gives the Hero a 20% chance to deal |cffff00ffmagic damage|r to enemies in a small area around the enemy.|n|n|cffc0c0c0Damage increases from hero block|r|r|n|n|cffffff00Ability level bonus|r|nDamage bonus|n|n|cffff00ffDamage at level 30|r: 3000 + 50% of the hero's block|n|cffd45e3aArea of effect at level 30|r: 300|n|n[|cffd45e29onhit|r][|cff80ff80Luck|r]"
         },
         {
           "Key": "ides",
@@ -50324,7 +50324,7 @@
         },
         {
           "Key": "utub",
-          "Value": "[|cffff0000Fire|r]|nEvery time the Hero is attacked it has a chance to deal |cffff00ffmagic damage|r to all nearby enemy units based on its strength.|n|n|cffffff00Ability level bonus|r|nStrength damage multiplier|n|n|cffff00ffDamage at level 30|r: 300% of the Hero's strength|n|n[|cff80ff80Luck|r]"
+          "Value": "[|cffff0000Fire|r]|nEvery time the Hero is attacked it has a chance to deal |cffff00ffmagic damage|r to all nearby enemy units based on its strength.|n|n|cffffff00Ability level bonus|r|nStrength damage multiplier|n|n|cffff00ffDamage at level 30|r: 302% of the Hero's strength|n|n[|cff80ff80Luck|r][|cff96ffffStable|r]"
         },
         {
           "Key": "ides",
@@ -53458,7 +53458,7 @@
         },
         {
           "Key": "utub",
-          "Value": "When the Hero deals |cffff8080physical damage|r, it has a 15% chance to deal |cffff00ffmagic damage|r to enemy units in a small area around the target.|n|n|cffc0c0c0Damage increases from the hero's primary stat|r|n|n|cffffff00Ability level bonus|r|nDamage|n|n|cffff00ffDamage at level 30|r: 12000 + 50% of the hero's primary stat|n|n[|cffd45e29onhit|r]"
+          "Value": "When the Hero deals |cffff8080physical damage|r, it has a 15% chance to deal |cffff00ffmagic damage|r to enemy units in a small area around the target.|n|n|cffc0c0c0Damage increases from the hero's primary stat|r|n|n|cffffff00Ability level bonus|r|nDamage|n|n|cffff00ffDamage at level 30|r: 12000 + 50% of the hero's primary stat|n|n[|cffd45e29onhit|r][|cff80ff80Luck|r]"
         },
         {
           "Key": "iclr",
@@ -58972,7 +58972,7 @@
         },
         {
           "Key": "utub",
-          "Value": "|cffff8080Effects|r|n* +10 magic power.|n|n[|cffff8c00Unique|r]|n|cff80ff80Abilities|r|n* Deals <A05L,DataA1> |cffff00ffmagic damage|r to <A05L,DataC1> nearby enemy creeps when used.|n|n|cffffff00Cooldown: |r<A05L,Cool1> seconds"
+          "Value": "|cffff8080Effects|r|n* +10 magic power.|n|n[|cffff8c00Unique|r]|n|cff80ff80Abilities|r|n* Deals <A05L,DataA1> |cffff00ffmagic damage|r to 10 nearby enemy creeps when used.|n|n|cffffff00Cooldown: |r<A05L,Cool1> seconds"
         },
         {
           "Key": "iico",
@@ -69402,7 +69402,7 @@
         },
         {
           "Key": "utub",
-          "Value": "[|cff6f2583Arcane|r]|nWhenever the Hero attacks an enemy it deals bonus |cffff8080physical|r attack damage to random nearby enemies. Cannot hit the same enemy multiple times in one attack.|n|n|cffc0c0c0Cannot be used in combination with Cleaving Attack or Multishot.|r|n|n|cffffff00Ability level bonus|r|nEnemies hit|n|n|cffff00ffMax targets at level 30|r: 10|n"
+          "Value": "[|cff6f2583Arcane|r]|nWhenever the Hero attacks an enemy it deals bonus |cffff8080physical|r attack damage to random nearby enemies. Cannot hit the same enemy multiple times in one attack.|n|n|cffffff00Ability level bonus|r|nEnemies hit|n|n|cffff00ffMax targets at level 30|r: 10|n"
         },
         {
           "Key": "ides",

--- a/Trigger/03-Data/01-Generic/IdLibrary.j
+++ b/Trigger/03-Data/01-Generic/IdLibrary.j
@@ -258,7 +258,7 @@ library IdLibrary initializer init
         constant integer FERAL_SPIRIT_ABILITY_ID                        = 'A0CA'
         constant integer FINGER_OF_DEATH_ABILITY_ID                     = 'Afod'
         constant integer FINISHING_BLOW_ABILITY_ID                      = 'A02N'
-        constant integer FIRE_FORCE_ABILITY_ID                          = 'A02U'
+        constant integer FIRE_FORCE_ABILITY_ID                          = 'A0D7'
         constant integer FIRE_SHIELD_ABILITY_ID                         = 'A01T'
         constant integer FLAME_STRIKE_ABILITY_ID                        = 'AHfs'
         constant integer FOG_ABILITY_ID                                 = 'Aclf'

--- a/Trigger/03-Data/02-Heroes/HeroPassiveDesc.j
+++ b/Trigger/03-Data/02-Heroes/HeroPassiveDesc.j
@@ -220,7 +220,7 @@ library HeroPassiveDesc initializer init requires HeroLvlTable, EconomyCreepBonu
         call InitHeroDesc(TROLL_BERSERKER_UNIT_ID, HeroPassive_Lvlup, "|cffffff00Level Up Bonus|r: +0.5% attack cooldown reduction." )
 
         call InitHeroDesc(YETI_UNIT_ID, HeroPassive_Icon, "ReplaceableTextures\\CommandButtons\\BTNWendigo.blp" )
-        call InitHeroDesc(YETI_UNIT_ID, HeroPassive_Desc, "|cff00ffffPassive|r: Yeti Strength: Gains +10% strength and an 8% chance to negate [|cff00ffffCrit|r] damage for every [|cff8080ffCold|r] it has. [|cff80ff80Luck|r]")
+        call InitHeroDesc(YETI_UNIT_ID, HeroPassive_Desc, "|cff00ffffPassive|r: Yeti Strength: Gains +10% base strength and an 8% chance to negate [|cff00ffffCrit|r] damage for every [|cff8080ffCold|r] it has. [|cff80ff80Luck|r]")
         call InitHeroDesc(YETI_UNIT_ID, HeroPassive_Lvlup, "|cffffff00Level Up Bonus|r: Yeti Strength: (|cff68eef3Every 10 levels|r) +1% strength bonus from  [|cff8080ffCold|r]." )
         
         call InitHeroDesc(SATYR_TRICKSTER_UNIT_ID, HeroPassive_Icon, "ReplaceableTextures\\CommandButtons\\BTNSatyr.blp" )

--- a/Trigger/04-Helpers/2-Multicast.j
+++ b/Trigger/04-Helpers/2-Multicast.j
@@ -47,11 +47,11 @@ library Multicast requires T32, RandomShit, AbilityChannel
             local DummyOrder dummy = DummyOrder.create(this.caster, GetUnitX(this.caster), GetUnitY(this.caster), GetUnitFacing(this.caster), 9)
             call dummy.addActiveAbility(this.abilId, this.abilLevel, this.abilOrder)
 
-            if this.orderType == 0 then
+            if this.orderType == Order_Instant then // 3
                 call dummy.instant()
-            elseif this.orderType == 1 then
+            elseif this.orderType == Order_Target then
                 call dummy.target(this.target)
-            else
+            elseif this.orderType == Order_Point then
                 call dummy.point(this.x, this.y)
             endif
 
@@ -64,7 +64,7 @@ library Multicast requires T32, RandomShit, AbilityChannel
         endmethod
 
         private method checkSpell takes nothing returns boolean
-            if this.orderType == 1 and this.mono then
+            if this.orderType == Order_Target and this.mono then
                 //call BJDebugMsg("new trgt: " + GetUnitName(this.target) + " count: " + I2S(this.count))
                 if not GetNewTarget(GetAbilityRealField(this.caster, this.abilId, this.abilLevel, ABILITY_RLF_CAST_RANGE)) then
                     //call BJDebugMsg("end")
@@ -125,7 +125,6 @@ library Multicast requires T32, RandomShit, AbilityChannel
             set this.y = y
             
             set this.count = count
-            set this.orderType = orderType
 
             set this.endTick = T32_Tick + MulticastInterval
             call this.startPeriodic()

--- a/Trigger/04-Helpers/AllowCasting.j
+++ b/Trigger/04-Helpers/AllowCasting.j
@@ -5,11 +5,11 @@ library AllowCasting
     endglobals
 
     private function IsUnitRestricted takes unit u returns boolean
-        return IsUnitInGroup(u, DuelWinnerDisabled) or RectContainsUnit(RectMidArena, u) or (IsUnitInGroup(u, DuelingHeroes) and IsPlayerInForce(GetOwningPlayer(u), RoundPlayersCompleted))
+        return IsUnitInGroup(u, DuelWinnerDisabled) or RectContainsUnit(RectMidArena, u)
     endfunction
 
     function IsCastingAllowed takes unit u returns boolean
-        return BrStarted or ElimPvpStarted or not IsUnitRestricted(u) or GetUnitTypeId(u) == SUDDEN_DEATH_UNIT_ID or GetUnitTypeId(u) == PRIEST_1_UNIT_ID
+        return BrStarted or not IsUnitRestricted(u) or GetUnitTypeId(u) == SUDDEN_DEATH_UNIT_ID or GetUnitTypeId(u) == PRIEST_1_UNIT_ID or (IsUnitInGroup(u, DuelingHeroes) and IsPlayerInForce(GetOwningPlayer(u), RoundPlayersCompleted))
     endfunction
 
     function SetCurrentlyFighting takes player p, boolean b returns nothing

--- a/Trigger/04-Helpers/AllowCasting.j
+++ b/Trigger/04-Helpers/AllowCasting.j
@@ -4,46 +4,12 @@ library AllowCasting
         boolean array CurrentlyFighting
     endglobals
 
-    private function CheckUnitGroup takes unit u returns boolean
-        if(not(IsUnitInGroup(u,DuelingHeroes)!=true)) then
-            return false
-        endif
-        if(not(IsPlayerInForce(GetOwningPlayer(u),RoundPlayersCompleted)==true)) then
-            return false
-        endif
-        return true
+    private function IsUnitRestricted takes unit u returns boolean
+        return IsUnitInGroup(u, DuelWinnerDisabled) or RectContainsUnit(RectMidArena, u) or (IsUnitInGroup(u, DuelingHeroes) and IsPlayerInForce(GetOwningPlayer(u), RoundPlayersCompleted))
     endfunction
-    
-    private function CheckUnit takes unit u returns boolean
-        if (IsUnitInGroup(u, DuelWinnerDisabled)==true) then
-            return true
-        endif
-        if((RectContainsUnit(RectMidArena,u)==true)) then
-            return true
-        endif
-        if(CheckUnitGroup(u)) then
-            return true
-        endif
-        return false
-    endfunction
-    
-    function CheckIfCastAllowed takes unit u returns boolean
-        if(not(BrStarted==false)) then
-            return false
-        endif
-        if(not(ElimPvpStarted==false)) then
-            return false
-        endif
-        if(not CheckUnit(u)) then
-            return false
-        endif
-        if(not(GetUnitTypeId(u)!=SUDDEN_DEATH_UNIT_ID)) then
-            return false
-        endif
-        if (not(GetUnitTypeId(u)!=PRIEST_1_UNIT_ID)) then
-            return false
-        endif	
-        return true
+
+    function IsCastingAllowed takes unit u returns boolean
+        return BrStarted or ElimPvpStarted or not IsUnitRestricted(u) or GetUnitTypeId(u) == SUDDEN_DEATH_UNIT_ID or GetUnitTypeId(u) == PRIEST_1_UNIT_ID
     endfunction
 
     function SetCurrentlyFighting takes player p, boolean b returns nothing

--- a/Trigger/04-Helpers/DummySpellCasts.j
+++ b/Trigger/04-Helpers/DummySpellCasts.j
@@ -39,8 +39,8 @@ library DummySpellCasts requires DummyOrder
         call dummy.target(u2).activate()
     endfunction
 
-    function DummyInstantCast1 takes unit u1, real x, real y,integer idsp, string ordstr, real life_1, abilityreallevelfield REALF returns nothing
-        local DummyOrder dummy = DummyOrder.create(u1, x, y, GetUnitFacing(u1), 9)
+    function DummyInstantCast1 takes unit u1, real x, real y,integer idsp, string ordstr, real life_1, abilityreallevelfield REALF, real duration returns nothing
+        local DummyOrder dummy = DummyOrder.create(u1, x, y, GetUnitFacing(u1), duration)
         call dummy.addActiveAbility(idsp, 1, OrderId(ordstr))
         if REALF != null then
             call dummy.setAbilityRealField(idsp, REALF, life_1)

--- a/Trigger/05-Game Functions/Heroes/15-HeroLvl.j
+++ b/Trigger/05-Game Functions/Heroes/15-HeroLvl.j
@@ -111,11 +111,11 @@ library HeroLevelup initializer init requires HeroLvlTable, Tinker, WitchDoctor,
             call SetBonus(u, 3, 1 + ((heroLevel - ModuloInteger(heroLevel, 75)) / 75))
             call PitlordLevelup(u, heroLevel)
         elseif uid == THUNDER_WITCH_UNIT_ID then      
-            set ThunderBoltTargets.integer[hid] = ((heroLevel - ModuloInteger(heroLevel, 30)) / 30)
+            set ThunderBoltTargets.integer[hid] = 1 + ((heroLevel - ModuloInteger(heroLevel, 30)) / 30)
             call SetBonus(u, 0, heroLevel * 30)
             call SetBonus(u, 1, ThunderBoltTargets[hid] + 1)
         elseif uid == SORCERER_UNIT_ID then      
-            set SorcererAmount.integer[hid] = ((heroLevel - ModuloInteger(heroLevel, 35)) / 35)
+            set SorcererAmount.integer[hid] = 1 + ((heroLevel - ModuloInteger(heroLevel, 35)) / 35)
             call SetBonus(u, 0, RMaxBJ(50 - heroLevel * 0.2, 15))
             call SetBonus(u, 1, SorcererAmount[hid])
         elseif uid == WOLF_RIDER_UNIT_ID then       
@@ -229,7 +229,7 @@ library HeroLevelup initializer init requires HeroLvlTable, Tinker, WitchDoctor,
         elseif uid == BANSHEE_UNIT_ID then
 
         elseif uid == CRYPT_LORD_UNIT_ID then      
-            set CryptLordLocustCount.integer[hid] = ((heroLevel - ModuloInteger(heroLevel, 10)) / 10)
+            set CryptLordLocustCount.integer[hid] = 1 + ((heroLevel - ModuloInteger(heroLevel, 10)) / 10)
             call SetBonus(u, 0, 60 * heroLevel)
             call SetBonus(u, 1, 1 + CryptLordLocustCount[hid])
 

--- a/Trigger/05-Game Functions/Heroes/15-HeroLvl.j
+++ b/Trigger/05-Game Functions/Heroes/15-HeroLvl.j
@@ -213,7 +213,7 @@ library HeroLevelup initializer init requires HeroLvlTable, Tinker, WitchDoctor,
         elseif uid == OGRE_WARRIOR_UNIT_ID then
             call SetBonus(u, 0, heroLevel * 60)
         elseif uid == OGRE_MAGE_UNIT_ID then
-            call SetBonus(u, 0, 15 + (heroLevel * 2))
+            call SetBonus(u, 0, 15 + (heroLevel * 1.2))
         elseif uid == SEER_UNIT_ID then
             call SetBonus(u, 0, 20 + (heroLevel * 0.33))
         elseif uid == TROLL_BERSERKER_UNIT_ID then

--- a/Trigger/05-Game Functions/Items/1-ItemBonus.j
+++ b/Trigger/05-Game Functions/Items/1-ItemBonus.j
@@ -77,9 +77,9 @@ library ItemBonus initializer init requires CustomState, ReplaceItem, RandomShit
 		
 			//Staff of Lightning
 		elseif itemId == 'I05C' then
-			call SetHeroStr(u, GetHeroStr(u, false) + (200 * uniqueDiff), false)
-			call SetHeroAgi(u, GetHeroAgi(u, false) + (200 * uniqueDiff), false)
-			call SetHeroInt(u, GetHeroInt(u, false) + (200 * uniqueDiff), false)
+			call AddUnitBonus(u, BONUS_STRENGTH, 200 * uniqueDiff)
+			call AddUnitBonus(u, BONUS_AGILITY, 200 * uniqueDiff)
+			call AddUnitBonus(u, BONUS_INTELLIGENCE, 200 * uniqueDiff)
 		
 			//Robe of the ARchmage
 		elseif itemId == 'I05B' then
@@ -143,7 +143,7 @@ library ItemBonus initializer init requires CustomState, ReplaceItem, RandomShit
 			call AddUnitCustomState(u, BONUS_PVP, 5 * diff)
 			call AddUnitCustomState(u, BONUS_EVASION, 20 * diff)
 			call AddStatLevelBonus(u, BONUS_AGILITY, 15 *diff)
-			call SetHeroAgi(u, GetHeroAgi(u, false) + (15 *diff)* GetHeroLevel(u), false)
+			call AddUnitBonus(u, BONUS_AGILITY, (15 * diff) * GetHeroLevel(u))
 			//call BlzSetUnitRealField(u,ConvertUnitRealField('uagp'), BlzGetUnitRealField(u,ConvertUnitRealField('uagp')) + 15*diff )
 			
 			//Ancient Axe
@@ -152,7 +152,7 @@ library ItemBonus initializer init requires CustomState, ReplaceItem, RandomShit
 			call AddUnitCustomState(u, BONUS_PVP, 5 * diff)
 			call AddUnitCustomState(u, BONUS_BLOCK, 900 * diff)
 			call AddStatLevelBonus(u, BONUS_STRENGTH, 15 *diff)
-			call SetHeroStr(u, GetHeroStr(u, false) + (15 *diff)* GetHeroLevel(u), false)
+			call AddUnitBonus(u, BONUS_STRENGTH, (15 * diff) * GetHeroLevel(u))
 			//call BlzSetUnitRealField(u,ConvertUnitRealField('ustp'), BlzGetUnitRealField(u,ConvertUnitRealField('ustp')) + 15*diff )
 
 			//Dried Mushroom
@@ -292,7 +292,7 @@ library ItemBonus initializer init requires CustomState, ReplaceItem, RandomShit
 			call AddUnitCustomState(u, BONUS_PVP, 5 * diff)
 			call AddUnitCustomState(u, BONUS_MAGICPOW, 20 * diff)
 			call AddStatLevelBonus(u, BONUS_INTELLIGENCE, 15 *diff)
-			call SetHeroInt(u, GetHeroInt(u, false) + (15 *diff)* GetHeroLevel(u), false)
+			call AddUnitBonus(u, BONUS_INTELLIGENCE, (15 * diff) * GetHeroLevel(u))
 			//call BlzSetUnitRealField(u,ConvertUnitRealField('uinp'), BlzGetUnitRealField(u,ConvertUnitRealField('uinp')) + 15*diff )
 		
 			//Archmage Staff

--- a/Trigger/05-Game Functions/Items/1-Toms.j
+++ b/Trigger/05-Game Functions/Items/1-Toms.j
@@ -241,12 +241,12 @@ library Tomes initializer init requires RandomShit, CustomState, NonLucrativeTom
 
                 //glory attack cooldown
             elseif itemTypeId  == GLORY_ATTACKCD_TOME_ITEM_ID then
-                if LoadReal(HT, GetHandleId(u), - 1001) - (LoadReal(HT, GetHandleId(u), - 1001) * GloryAttackCdBonus.real[GetHandleId(u)]) > 0.40 and BuyGloryItem(pid, itemTypeId) then
+                if LoadReal(HT, GetHandleId(u), - 1001) - (LoadReal(HT, GetHandleId(u), - 1001) * GloryAttackCdBonus.real[GetHandleId(u)]) > 0.60 and BuyGloryItem(pid, itemTypeId) then
                     set GloryAttackCdLevel.integer[GetHandleId(u)] = GloryAttackCdLevel.integer[GetHandleId(u)] + 1
                     set GloryAttackCdBonus.real[GetHandleId(u)] = 1 - Pow(0.94, GloryAttackCdLevel.integer[GetHandleId(u)])
                     set gloryBonus = BlzGetUnitAttackCooldown(u, 0) - ModifyAttackCooldown(u, GetHandleId(u))
                 else
-                    if LoadReal(HT, GetHandleId(u), - 1001) - (LoadReal(HT, GetHandleId(u), - 1001) * GloryAttackCdBonus.real[GetHandleId(u)]) <= 0.40 then
+                    if LoadReal(HT, GetHandleId(u), - 1001) - (LoadReal(HT, GetHandleId(u), - 1001) * GloryAttackCdBonus.real[GetHandleId(u)]) <= 0.60 then
                         call DisplayTimedTextToPlayer(p, 0, 0, 2, "|cffdf9432Glory Attack Cooldown cannot go lower than 0.60.|r")
                     endif
                     set ctrl = false

--- a/Trigger/05-Game Functions/Mechanics/2-Damage System/2. ModifyDamageBeforeArmor.j
+++ b/Trigger/05-Game Functions/Mechanics/2-Damage System/2. ModifyDamageBeforeArmor.j
@@ -306,7 +306,7 @@ scope ModifyDamageBeforeArmor initializer init
         endif
 
         //Demon Hunter
-        if GetUnitTypeId(DamageSource) == DEMON_HUNTER_UNIT_ID and (IsMagicDamage() and CheckUnitHitCooldown(DamageTargetId, DEMON_HUNTER_UNIT_ID, 0.7) or IsPhysDamage()) then
+        if GetUnitTypeId(DamageSource) == DEMON_HUNTER_UNIT_ID and ((IsMagicDamage() and CheckUnitHitCooldown(DamageTargetId, DEMON_HUNTER_UNIT_ID, 0.7)) or IsPhysDamage()) then
             set r1 = RMinBJ(GetHeroLevel(DamageSource) * 20, GetUnitState(DamageTarget, UNIT_STATE_MANA))
             call SetUnitState(DamageTarget, UNIT_STATE_MANA, GetUnitState(DamageTarget, UNIT_STATE_MANA) - r1)
             call SetUnitState(DamageSource, UNIT_STATE_MANA, GetUnitState(DamageSource, UNIT_STATE_MANA) + r1)

--- a/Trigger/05-Game Functions/Mechanics/2-Damage System/3. ModifyDamageAfterArmor.j
+++ b/Trigger/05-Game Functions/Mechanics/2-Damage System/3. ModifyDamageAfterArmor.j
@@ -474,9 +474,9 @@ scope ModifyDamageAfterArmor initializer init
         if DamageTargetTypeId == MURLOC_WARRIOR_UNIT_ID and GetHeroStr(DamageTarget, true) < 2147483647 then
             set i1 = 1 + GetHeroLevel(DamageTarget)/ 10 
             call SaveInteger(HT,DamageTargetId,54021,i1 + LoadInteger(HT,DamageTargetId,54021))
-            call SetHeroStr(DamageTarget,GetHeroStr(DamageTarget,false)+ i1,false)
-            call SetHeroAgi(DamageTarget,GetHeroAgi(DamageTarget,false)+ i1,false)
-            call SetHeroInt(DamageTarget,GetHeroInt(DamageTarget,false)+ i1,false)
+            call AddUnitBonus(DamageTarget, BONUS_STRENGTH, i1)
+            call AddUnitBonus(DamageTarget, BONUS_AGILITY, i1)
+            call AddUnitBonus(DamageTarget, BONUS_INTELLIGENCE, i1)
         endif
 
         //Decaying Scythe

--- a/Trigger/05-Game Functions/Mechanics/2-Damage System/3. ModifyDamageAfterArmor.j
+++ b/Trigger/05-Game Functions/Mechanics/2-Damage System/3. ModifyDamageAfterArmor.j
@@ -184,8 +184,8 @@ scope ModifyDamageAfterArmor initializer init
         
         //Combustion
         if GetUnitAbilityLevel(DamageSourceHero, COMBUSTION_ABILITY_ID) > 0 and IsMagicDamage() and BlzGetUnitAbilityCooldownRemaining(DamageSourceHero,COMBUSTION_ABILITY_ID) <= 0 then
-            call AbilStartCD(DamageSourceHero,COMBUSTION_ABILITY_ID,0.3)
-            set Damage.index.amount = Damage.index.amount + 30 * GetUnitAbilityLevel(DamageSourceHero   ,COMBUSTION_ABILITY_ID)
+            call AbilStartCD(DamageSourceHero, COMBUSTION_ABILITY_ID, 0.3)
+            set Damage.index.amount = Damage.index.amount + 30 * GetUnitAbilityLevel(DamageSourceHero, COMBUSTION_ABILITY_ID)
             call DestroyEffect( AddLocalizedSpecialEffectTarget("Abilities\\Weapons\\RedDragonBreath\\RedDragonMissile.mdl", DamageTarget, "chest"))
         endif
 

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/1-AttackController.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/1-AttackController.j
@@ -37,9 +37,9 @@ scope AttackController initializer init
         if GetUnitTypeId(attacker) == MURLOC_WARRIOR_UNIT_ID then
             set i1 = 1 + GetHeroLevel(attacker)/ 10 
             call SaveInteger(HT, GetHandleId(attacker),54021, i1 + LoadInteger(HT, GetHandleId(attacker),54021))
-            call SetHeroStr(attacker, GetHeroStr(attacker, false) + i1, false)
-            call SetHeroAgi(attacker, GetHeroAgi(attacker, false) + i1, false)
-            call SetHeroInt(attacker, GetHeroInt(attacker, false) + i1, false)
+            call AddUnitBonus(attacker, BONUS_STRENGTH, i1)
+            call AddUnitBonus(attacker, BONUS_AGILITY, i1)
+            call AddUnitBonus(attacker, BONUS_INTELLIGENCE, i1)
         endif
 
         //Huntress

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/1-AttackController.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/1-AttackController.j
@@ -46,7 +46,7 @@ scope AttackController initializer init
         if GetUnitTypeId(attacker) == HUNTRESS_UNIT_ID then
             if BlzGetUnitAbilityCooldownRemaining(attacker, 'A0DW') == 0 then
                 call ElemFuncStart(attacker, HUNTRESS_UNIT_ID)
-                call DummyInstantCast1(attacker, GetUnitX(attacker), GetUnitY(attacker), 'A035', "fanofknives",  RMaxBJ(7, GetAttackDamage(attackerHero)* (0.245 + (0.005 * GetHeroLevel(attackerHero)))) , ConvertAbilityRealLevelField('Ocl1'))
+                call DummyInstantCast1(attacker, GetUnitX(attacker), GetUnitY(attacker), 'A035', "fanofknives",  RMaxBJ(7, GetAttackDamage(attackerHero)* (0.245 + (0.005 * GetHeroLevel(attackerHero)))) , ConvertAbilityRealLevelField('Ocl1'), 4)
                 call AbilStartCD(attacker, 'A0DW', 1)
             endif
         endif
@@ -94,9 +94,11 @@ scope AttackController initializer init
         endif
 
         //Fire Force
-        set i1 = GetUnitAbilityLevel(target,FIRE_FORCE_ABILITY_ID)
-        if i1 > 0 and (GetRandomReal(1, 100)<= 25 * targetLuck) then
-            call DummyInstantCast1(target, GetUnitX(target), GetUnitY(target), 'A0C0', "fanofknives", GetHeroStr(target,true) * (0.62 + (0.08 * i1)), ConvertAbilityRealLevelField('Ocl1'))
+        set i1 = GetUnitAbilityLevel(target, FIRE_FORCE_ABILITY_ID)
+        if i1 > 0 and BlzGetUnitAbilityCooldownRemaining(target, FIRE_FORCE_ABILITY_ID) == 0 and (GetRandomReal(1, 100) <= 25 * targetLuck) then
+            call BlzStartUnitAbilityCooldown(target, FIRE_FORCE_ABILITY_ID, 0.3)
+            call BlzStartUnitAbilityCooldown(target, GetDummySpell(target, FIRE_FORCE_ABILITY_ID), 0.3)
+            call DummyInstantCast1(target, GetUnitX(target), GetUnitY(target), 'A0C0', "fanofknives", GetHeroStr(target,true) * (0.62 + (0.08 * i1)), ConvertAbilityRealLevelField('Ocl1'), 4)
         endif
 
         // Cleanup

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/2-ShortPeriodCheck.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/2-ShortPeriodCheck.j
@@ -210,7 +210,7 @@ scope ShortPeriodCheck initializer init
                 //Yeti
             elseif unitTypeId == YETI_UNIT_ID then
                 set i1 = LoadInteger(DataUnitHT, hid, YETI_UNIT_ID)
-                set i2 = R2I((GetHeroStr(u, true) - i1) * ((YetiStrengthBonus.integer[hid] * 0.01) * GetUnitElementCount(u, Element_Cold)))
+                set i2 = R2I((GetHeroStr(u, false) - i1) * ((YetiStrengthBonus.integer[hid] * 0.01) * GetUnitElementCount(u, Element_Cold)))
                 if i1 != i2 then
                     call SetHeroStr(u, GetHeroStr(u, false) - i1 + i2, false)
                     call SaveInteger(DataUnitHT, hid, YETI_UNIT_ID, i2)

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/2-ShortPeriodCheck.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/2-ShortPeriodCheck.j
@@ -58,7 +58,7 @@ scope ShortPeriodCheck initializer init
                 //Power of Ice
                 if GetUnitAbilityLevel(u, POWER_OF_ICE_ABILITY_ID) >= 1 then
                     if CheckProc(u, 610) then
-                        call DummyInstantCast1(u, GetUnitX(u), GetUnitY(u),'A02Y',"fanofknives", (100 * GetUnitAbilityLevel(u, POWER_OF_ICE_ABILITY_ID)) * (1 + (GetHeroLevel(u)* 0.02)), ConvertAbilityRealLevelField('Ocl1'))
+                        call DummyInstantCast1(u, GetUnitX(u), GetUnitY(u),'A02Y',"fanofknives", (100 * GetUnitAbilityLevel(u, POWER_OF_ICE_ABILITY_ID)) * (1 + (GetHeroLevel(u)* 0.02)), ConvertAbilityRealLevelField('Ocl1'), 4)
                     endif
                 endif
                 

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/3-LongPeriodCheck.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/3-LongPeriodCheck.j
@@ -289,7 +289,7 @@ scope LongPeriodCheck initializer init
             set i2 = LoadInteger(HT, hid,ABSOLUTE_WATER_ABILITY_ID)
             if i1 >= 1 or i2 != 0 then
                 set i1 = R2I(i1 * GetUnitElementCount(u, Element_Water)/* * (1+ GetUnitAbsoluteEffective(u, Element_Water))*/)
-                call SetHeroInt(u, GetHeroInt(u, false) + (10 * (i1 -i2)), false)
+                call AddUnitBonus(u, BONUS_INTELLIGENCE, 10 * (i1 - i2))
                 call BlzSetUnitMaxMana(u, BlzGetUnitMaxMana(u) +(30 * (i1 -i2)))
 
                 call SaveInteger(HT, hid,ABSOLUTE_WATER_ABILITY_ID,i1)
@@ -301,7 +301,7 @@ scope LongPeriodCheck initializer init
             if i1 >= 1 or i2 != 0 then
                 set i1 = R2I(i1 * GetUnitElementCount(u, Element_Wind)/* * (1+ GetUnitAbsoluteEffective(u, Element_Wind))*/)
                 call AddUnitCustomState(u , BONUS_EVASION,   0.25 * I2R(i1 - i2) )
-                call SetHeroAgi(u,GetHeroAgi(u, false)+ 10 *(i1 - i2), false    )
+                call AddUnitBonus(u, BONUS_AGILITY, 10 * (i1 - i2))
                 call SaveInteger(HT, hid,ABSOLUTE_WIND_ABILITY_ID,i1)	
             endif
 
@@ -319,7 +319,7 @@ scope LongPeriodCheck initializer init
             set i2 = LoadInteger(HT, hid,ABSOLUTE_BLOOD_ABILITY_ID)
             if i1 >= 1 or i2 != 0 then
                 set i1 = R2I(i1 * GetUnitElementCount(u, Element_Blood)/* * (1+ GetUnitAbsoluteEffective(u, Element_Blood))*/)
-                call SetHeroStr(u,GetHeroStr(u, false)+ 10 *(i1 - i2), false    )
+                call AddUnitBonus(u, BONUS_STRENGTH, 10 * (i1 - i2))
                 call SaveInteger(HT, hid,ABSOLUTE_BLOOD_ABILITY_ID,i1)	
             endif
 

--- a/Trigger/05-Game Functions/Mechanics/Unsorted/ItemStock.j
+++ b/Trigger/05-Game Functions/Mechanics/Unsorted/ItemStock.j
@@ -150,8 +150,10 @@ library ItemStock initializer init requires Table
     endfunction
 
     function KillItemStock takes integer pid returns nothing
-        call RemoveUnit(ItemStock.unit[pid])
-        call ItemStock.remove(pid)
+        if ItemStockEnabled then
+            call RemoveUnit(ItemStock.unit[pid])
+            call ItemStock.remove(pid)
+        endif
     endfunction
 
     function CreateItemStock takes nothing returns nothing

--- a/Trigger/06-UI/22-HeroSelector/HeroInfo.j
+++ b/Trigger/06-UI/22-HeroSelector/HeroInfo.j
@@ -170,8 +170,9 @@ library HeroInfo initializer init_function requires GetObjectElement, HeroPassiv
         local string heroData
         local ability abi
         local integer abiIndex
-        local string descriptionTemp = ""
+        local string descriptionTemp
         local string description = ""
+        local string heroNamePrefix
 
         if DetectUnitSkills then
             set dummyUnit = CreateUnit(Player(GetPlayerNeutralPassive()), unitCode, 0, 0, 0)
@@ -180,26 +181,25 @@ library HeroInfo initializer init_function requires GetObjectElement, HeroPassiv
         // Reset the global Buttons Index
         set ButtonCurrentIndex = 0
     
-    
+        set heroNamePrefix = DescHeroNamePrefix + GetObjectName(unitCode) + DescHeroNameSufix
+
+        set descriptionTemp = GetObjectElementsAsString(null, unitCode, false)
+        if descriptionTemp != "" then
+            set description = description + descriptionTemp + "|n"
+        endif
+
+        set descriptionTemp = GetHeroPassiveDescription(unitCode, HeroPassive_Desc)
+        if descriptionTemp != "" and descriptionTemp != null then
+            set description = description + descriptionTemp + "|n"
+        endif
+
+        set descriptionTemp = GetHeroPassiveDescription(unitCode, HeroPassive_Lvlup)
+        if descriptionTemp != "" and descriptionTemp != null then
+            set description = description + descriptionTemp
+        endif
+
         if GetLocalPlayer() == p then
-            call BlzFrameSetText(TextDisplay, DescHeroNamePrefix + GetObjectName(unitCode) + DescHeroNameSufix)
-
-            set descriptionTemp = GetObjectElementsAsString(null, unitCode, false)
-            if descriptionTemp != "" then
-                set description = description + descriptionTemp + "|n"
-            endif
-
-            set descriptionTemp = GetHeroPassiveDescription(unitCode, HeroPassive_Desc)
-            if descriptionTemp != "" and descriptionTemp != null then
-                set description = description + descriptionTemp + "|n"
-            endif
-
-            set descriptionTemp = GetHeroPassiveDescription(unitCode, HeroPassive_Lvlup)
-            if descriptionTemp != "" and descriptionTemp != null then
-                set description = description + descriptionTemp
-            endif
-
-            
+            call BlzFrameSetText(TextDisplay, heroNamePrefix)
             call BlzFrameAddText(TextDisplay, description)
     
             /*if HaveSavedString(HeroSelector_Hash, 0, unitCode) then

--- a/Trigger/06-UI/22-HeroSelector/HeroSelector.j
+++ b/Trigger/06-UI/22-HeroSelector/HeroSelector.j
@@ -1456,10 +1456,14 @@ library HeroSelector initializer init_function requires optional FrameLoader, Ga
             call HeroSelectorDoRandom(p)
         else
             set unitCode = HeroSelectorRollOption(p, false, PlayerSelectedButtonIndex[playerIndex], PlayerSelectedCategory[playerIndex], false)
-            if unitCode > 0 and GetLocalPlayer() == p then
+
+            if unitCode > 0 then
                 set unitCodeIndex = LoadInteger(Hash, unitCode, 0)
                 set buttonIndex = HeroButtonIndex[unitCodeIndex]
-                call BlzFrameClick(HeroButtonFrame[buttonIndex])
+
+                if GetLocalPlayer() == p then
+                    call BlzFrameClick(HeroButtonFrame[buttonIndex])
+                endif
             endif
         endif
         set p = null

--- a/Trigger/06-UI/22-HeroSelector/HeroSelectorAction.j
+++ b/Trigger/06-UI/22-HeroSelector/HeroSelectorAction.j
@@ -79,14 +79,17 @@ library HeroSelectorAction initializer Init uses HeroSelector, HeroInfo, PlayerH
         local player p = HeroSelectorEventPlayer
         local integer playerIndex = GetPlayerId(p)
         local integer unitCode = HeroSelectorEventUnitCode
+        local playercolor playersColor = GetPlayerColor(p)
+
         call HeroInfoButtonSelected(p, unitCode)
 
         if (GetLocalPlayer() == p) then
             call BlzSetUnitSkin(PreviewUnit, unitCode)
-            call SetUnitColor(PreviewUnit, GetPlayerColor(p))
+            call SetUnitColor(PreviewUnit, playersColor)
         endif
 
         set p = null
+        set playersColor = null
     endfunction
 
     function HeroSelectorRepick takes unit u returns nothing

--- a/Trigger/06-UI/AchievementsFrame.j
+++ b/Trigger/06-UI/AchievementsFrame.j
@@ -166,6 +166,7 @@ library AchievementsFrame initializer init requires TooltipFrame, PlayerTracking
         local integer i = 0
         local Requirements hr
         local PlayerStats ps = PlayerStats.forPlayer(p)
+        local string iconPath
 
         loop
             exitwhen i > TotalAchievementCount
@@ -173,12 +174,16 @@ library AchievementsFrame initializer init requires TooltipFrame, PlayerTracking
 
             if hr != 0 then
                 if hr.checkRequirements(ps) then
+                    set iconPath = GetIconPath(AchievementIconPaths.string[i])
+
                     if GetLocalPlayer() == p then
-                        call BlzFrameSetTexture(AchievementButtonBackdropFrames.framehandle[i], GetIconPath(AchievementIconPaths.string[i]), 0, true)
+                        call BlzFrameSetTexture(AchievementButtonBackdropFrames.framehandle[i], iconPath, 0, true)
                     endif
                 else
+                    set iconPath = GetDisabledIconPath(AchievementIconPaths.string[i])
+
                     if GetLocalPlayer() == p then
-                        call BlzFrameSetTexture(AchievementButtonBackdropFrames.framehandle[i], GetDisabledIconPath(AchievementIconPaths.string[i]), 0, true)
+                        call BlzFrameSetTexture(AchievementButtonBackdropFrames.framehandle[i], iconPath, 0, true)
                     endif
                 endif
             endif
@@ -193,6 +198,7 @@ library AchievementsFrame initializer init requires TooltipFrame, PlayerTracking
         local PlayerStats ps = PlayerStats.forPlayer(GetTriggerPlayer())
         local Requirements hr = Requirements.forIndex(index)
         local string requirementDescription
+        local real tooltipSize
 
         if BlzGetTriggerFrameEvent() == FRAMEEVENT_CONTROL_CLICK then
             if GetLocalPlayer() == GetTriggerPlayer() then
@@ -209,11 +215,12 @@ library AchievementsFrame initializer init requires TooltipFrame, PlayerTracking
             endif
         elseif BlzGetTriggerFrameEvent() == FRAMEEVENT_MOUSE_ENTER then
             set requirementDescription = hr.getRequirementDescription(ps)
+            set tooltipSize = GetTooltipSize(requirementDescription)
 
             // We are hijacking the tooltip window that we use for almost everything else in the game from IconFrames
             if GetLocalPlayer() == GetTriggerPlayer() then	
                 call BlzFrameSetText(TooltipTitleFrame, requirementDescription)
-                call BlzFrameSetSize(TooltipFrame, 0.29, GetTooltipSize(requirementDescription))
+                call BlzFrameSetSize(TooltipFrame, 0.29, tooltipSize)
                 call BlzFrameSetVisible(TooltipFrame, true)
             endif
         elseif BlzGetTriggerFrameEvent() == FRAMEEVENT_MOUSE_LEAVE then

--- a/Trigger/06-UI/BRLivesFrame.j
+++ b/Trigger/06-UI/BRLivesFrame.j
@@ -29,11 +29,13 @@ library BRLivesFrame initializer init requires PlayerTracking, Utility
     endfunction
 
     function UpdateLivesForPlayer takes player p, integer lives, boolean isBr returns nothing
+        local string livesText = I2S(lives)
+
         if (GetLocalPlayer() == p) then
             if (isBr) then
-                call BlzFrameSetText(BRLivesTextFrameHandle, BR_LIVES_TITLE_TEXT + ": " + I2S(lives))
+                call BlzFrameSetText(BRLivesTextFrameHandle, BR_LIVES_TITLE_TEXT + ": " + livesText)
             else
-                call BlzFrameSetText(BRLivesTextFrameHandle, LIVES_TITLE_TEXT + ": " + I2S(lives))
+                call BlzFrameSetText(BRLivesTextFrameHandle, LIVES_TITLE_TEXT + ": " + livesText)
             endif
         endif
     endfunction

--- a/Trigger/06-UI/BattleCreator/BattleCreator.j
+++ b/Trigger/06-UI/BattleCreator/BattleCreator.j
@@ -248,6 +248,7 @@ library BattleCreator initializer init requires PlayerTracking, Utility, BattleC
         local real tooltipWidth = 0.32
         local string tooltipDescription
         local string tooltipName
+        local real tooltipSize
         local boolean change = false
 
         if (BlzGetTriggerFrameEvent() == FRAMEEVENT_CONTROL_CLICK) then
@@ -259,8 +260,9 @@ library BattleCreator initializer init requires PlayerTracking, Utility, BattleC
             if (handleId == CloseHandleId) then
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetVisible(BattleCreatorFrameHandle, false) 
-                    call PlayerStats.forPlayer(triggerPlayer).setHasBattleCreatorOpen(false)
                 endif
+
+                call PlayerStats.forPlayer(triggerPlayer).setHasBattleCreatorOpen(false)
             elseif (IsPlayerInForce(triggerPlayer, BRRandomTeam)) then
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetText(BRMessageTextFrameHandle, BR_MESSAGE_COLOR + "You must unselect from the Random Teams Vote first!" + BR_COLOR_END_TAG)
@@ -283,12 +285,13 @@ library BattleCreator initializer init requires PlayerTracking, Utility, BattleC
         elseif (BlzGetTriggerFrameEvent() == FRAMEEVENT_MOUSE_ENTER) then
             set tooltipName = BRHandleTitles.string[handleId]
             set tooltipDescription = BRHandleDescriptions.string[handleId]
+            set tooltipSize = GetTooltipSize(tooltipDescription)
 
             if (GetLocalPlayer() == triggerPlayer) then	
                 call BlzFrameSetText(BattleCreatorTooltipTitleFrame, tooltipName)
                 call BlzFrameSetText(BattleCreatorTooltipTextFrame, tooltipDescription)
                 call BlzFrameSetPoint(BattleCreatorTooltipFrame, FRAMEPOINT_TOP, currentFrameHandle, FRAMEPOINT_BOTTOM, 0, 0)
-                call BlzFrameSetSize(BattleCreatorTooltipFrame, tooltipWidth, GetTooltipSize(tooltipDescription))
+                call BlzFrameSetSize(BattleCreatorTooltipFrame, tooltipWidth, tooltipSize)
                 call BlzFrameSetVisible(BattleCreatorTooltipFrame, true)
             endif
 

--- a/Trigger/06-UI/IconFrames.j
+++ b/Trigger/06-UI/IconFrames.j
@@ -351,7 +351,7 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 
 		elseif BlzGetTriggerFrameEvent() == FRAMEEVENT_MOUSE_LEAVE then
 			if GetLocalPlayer() == p then	
-				call BlzFrameSetText(TooltipTextFrame, description)
+				call BlzFrameSetText(TooltipTextFrame, "")
 				call BlzFrameSetVisible(TooltipFrame, false)
 			endif
 		endif

--- a/Trigger/06-UI/IconFrames.j
+++ b/Trigger/06-UI/IconFrames.j
@@ -161,7 +161,7 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 				endif
 			elseif NumButton == 8 then
 
-				if GetLocalPlayer() == p then
+				if ItemStockEnabled and GetLocalPlayer() == p then
 					call SelectUnitSingle(GetItemStock(pid))
 				endif
 			endif

--- a/Trigger/06-UI/IconFrames.j
+++ b/Trigger/06-UI/IconFrames.j
@@ -184,7 +184,7 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 				if GetLocalPlayer() == p then
 					call BlzFrameSetText(TooltipTitleFrame, "|cfffce177Next level|r: " + RoundCreepTitle)
 					call BlzFrameSetText(TooltipTextFrame, RoundCreepInfo[pid] + "|n|n|cfffce177Abilities|r: " + RoundAbilities)
-					call BlzFrameSetSize(TooltipFrame, 0.29, 0.12 + tooltipSize)
+					call BlzFrameSetSize(TooltipFrame, 0.29, 0.13 + tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 

--- a/Trigger/06-UI/IconFrames.j
+++ b/Trigger/06-UI/IconFrames.j
@@ -90,12 +90,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 	endfunction
 
 	private function SkillSysStart takes nothing returns nothing
-		local integer NumButton = LoadInteger(ButtonParentHandles, GetHandleId(BlzGetTriggerFrame()), 1)
+		local framehandle frame = BlzGetTriggerFrame()
+		local integer NumButton = LoadInteger(ButtonParentHandles, GetHandleId(frame), 1)
 		local player p = GetTriggerPlayer()
 		local integer pid = GetPlayerId(p)
-		local string tooltipTitle = ""
-		local string description = ""
-		local string temp = ""
+		local string tooltipTitle
+		local string description
+		local string temp
 		local boolean toggleBool = false
 		local integer i1
 		local integer i2
@@ -103,12 +104,14 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 		local unit u = null
 		local integer selectedUnitPid = SelectedUnitPid[pid]
 		local PlayerStats ps
+		local unit itemStock
+		local real tooltipSize
 
 		if BlzGetTriggerFrameEvent() ==  FRAMEEVENT_CONTROL_CLICK then
 			
 			if p == GetLocalPlayer() then
-				call BlzFrameSetEnable(BlzGetTriggerFrame(), false)
-				call BlzFrameSetEnable(BlzGetTriggerFrame(), true)
+				call BlzFrameSetEnable(frame, false)
+				call BlzFrameSetEnable(frame, true)
 			endif
 
 			// Sell all items
@@ -160,9 +163,10 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 					call BlzFrameSetVisible(MainAchievementFrameHandle, toggleBool)
 				endif
 			elseif NumButton == 8 then
+				set itemStock = GetItemStock(pid)
 
 				if GetLocalPlayer() == p then
-					call SelectUnitSingle(GetItemStock(pid))
+					call SelectUnitSingle(itemStock)
 				endif
 			endif
 
@@ -175,18 +179,21 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 
 			// Creep information
 			if NumButton == 2 then
+				set tooltipSize = GetTooltipSize(RoundAbilities)
+
 				if GetLocalPlayer() == p then
 					call BlzFrameSetText(TooltipTitleFrame, "|cfffce177Next level|r: " + RoundCreepTitle)
-					set temp = RoundCreepInfo[pid] + "|n|n|cfffce177Abilities|r: " + RoundAbilities
-					call BlzFrameSetText(TooltipTextFrame, temp)
-					call BlzFrameSetSize(TooltipFrame, 0.29, 0.12 + GetTooltipSize(RoundAbilities))
+					call BlzFrameSetText(TooltipTextFrame, RoundCreepInfo[pid] + "|n|n|cfffce177Abilities|r: " + RoundAbilities)
+					call BlzFrameSetSize(TooltipFrame, 0.29, 0.12 + tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
 			// Sell all items
 			elseif NumButton == 3 then
+				set description = SellAllItemsTooltip()
+
 				if GetLocalPlayer() == p then
-					call BlzFrameSetText(TooltipTitleFrame, SellAllItemsTooltip())
+					call BlzFrameSetText(TooltipTitleFrame, description)
 					call BlzFrameSetSize(TooltipFrame, 0.31, 0.02)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
@@ -219,11 +226,12 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 			elseif NumButton == 5 then
 				set tooltipTitle = ReadyButtonTooltipTitle(p)
 				set description = ReadyButtonTooltip(p, pid)
+				set tooltipSize = GetTooltipSize(description)
 
 				if GetLocalPlayer() == p then
 					call BlzFrameSetText(TooltipTitleFrame, tooltipTitle)
 					call BlzFrameSetText(TooltipTextFrame, description)
-					call BlzFrameSetSize(TooltipFrame, 0.31, GetTooltipSize(description))
+					call BlzFrameSetSize(TooltipFrame, 0.31, tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
@@ -231,11 +239,12 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 			elseif NumButton == 38 then
 				set u = PlayerHeroes[selectedUnitPid]
 				set description = GetElementCountTooltip(u)
+				set tooltipSize = GetTooltipSize(description)
 
 				if GetLocalPlayer() == p then
 					call BlzFrameSetText(TooltipTitleFrame, "|cffd0ff00Element Counts|r")
 					call BlzFrameSetText(TooltipTextFrame, description)
-					call BlzFrameSetSize(TooltipFrame, 0.125, GetTooltipSize(description))
+					call BlzFrameSetSize(TooltipFrame, 0.125, tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
@@ -246,10 +255,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 				else
 					set description = "When the Battle Royale preperation starts you can store extra items in your item stock, and swap them in during the Battle Royale.|n|n|cffd0ff00Ctrl+Q|r: Swaps items in slot 1.|n|cff00ffffCtrl+W|r: Swaps items in slot 2.|r"
 				endif
+
+				set tooltipSize = GetTooltipSize(description)
+
 				if GetLocalPlayer() == p then
 					call BlzFrameSetText(TooltipTitleFrame, "|cffd0ff00Storage Box|r")
 					call BlzFrameSetText(TooltipTextFrame, description)
-					call BlzFrameSetSize(TooltipFrame, 0.23, GetTooltipSize(description))
+					call BlzFrameSetSize(TooltipFrame, 0.23, tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
@@ -258,11 +270,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 				set u = PlayerHeroes[selectedUnitPid]
 				set description = PlayerStats.getTooltip(GetOwningPlayer(u))
 				set description = description + "|n|n|cffff0000Clicking this toggles the rewards menu!|r"
+				set tooltipSize = GetTooltipSize(description)
+				set temp = GetPlayerNameColour(GetOwningPlayer(u))
 
 				if GetLocalPlayer() == p then
-					call BlzFrameSetText(TooltipTitleFrame, "|cffd0ff00Stats for: |r" + GetPlayerNameColour(GetOwningPlayer(u)))
+					call BlzFrameSetText(TooltipTitleFrame, "|cffd0ff00Stats for: |r" + temp)
 					call BlzFrameSetText(TooltipTextFrame, description)
-					call BlzFrameSetSize(TooltipFrame, 0.23, GetTooltipSize(description))
+					call BlzFrameSetSize(TooltipFrame, 0.23, tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
@@ -291,11 +305,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 			elseif NumButton == 100 then
 				set u = PlayerHeroes[selectedUnitPid]
 				set description = GetHeroTooltip(u)
+				set tooltipSize = GetTooltipSize(description)
+				set temp = GetPlayerNameColour(GetOwningPlayer(u)) + ": " + "|cffffa8a8" + GetObjectName(GetUnitTypeId(u))
 
 				if GetLocalPlayer() == p then
-					call BlzFrameSetText(TooltipTitleFrame, GetPlayerNameColour(GetOwningPlayer(u)) + ": " + "|cffffa8a8" + GetObjectName(GetUnitTypeId(u)))
+					call BlzFrameSetText(TooltipTitleFrame, temp)
 					call BlzFrameSetText(TooltipTextFrame, description)
-					call BlzFrameSetSize(TooltipFrame, 0.29, GetTooltipSize(description))
+					call BlzFrameSetSize(TooltipFrame, 0.29, tooltipSize)
 					call BlzFrameSetVisible(TooltipFrame, true)
 				endif
 
@@ -306,11 +322,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 					set u = PlayerHeroes[selectedUnitPid]
 					set i3 = GetHeroSpellAtPosition(u, NumButton - 100) 
 					set description = GetAbilityElementCountTooltip(u, NumButton - 100)
+					set tooltipSize = GetTooltipSize(description)
+					set temp = BlzGetAbilityTooltip(i3, GetUnitAbilityLevel(u,i3) - 1)
 
 					if GetLocalPlayer() == p then	
-						call BlzFrameSetText(TooltipTitleFrame, BlzGetAbilityTooltip(i3, GetUnitAbilityLevel(u,i3) - 1))
+						call BlzFrameSetText(TooltipTitleFrame, temp)
 						call BlzFrameSetText(TooltipTextFrame, description)
-						call BlzFrameSetSize(TooltipFrame, 0.29, GetTooltipSize(description))
+						call BlzFrameSetSize(TooltipFrame, 0.29, tooltipSize)
 						call BlzFrameSetVisible(TooltipFrame, true)
 					endif 
 					
@@ -319,11 +337,13 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 					set u = SelectedUnit[pid]
 					set i3 = roundAbilities.integer[NumButton - 100]
 					set description = BlzGetAbilityExtendedTooltip(i3, GetUnitAbilityLevel(u,i3)- 1)
+					set tooltipSize = GetTooltipSize(description)
+					set temp = BlzGetAbilityTooltip(i3, GetUnitAbilityLevel(u,i3) - 1)
 
 					if GetLocalPlayer() == p then	
-						call BlzFrameSetText(TooltipTitleFrame, BlzGetAbilityTooltip(i3, GetUnitAbilityLevel(u,i3) - 1))
+						call BlzFrameSetText(TooltipTitleFrame, temp)
 						call BlzFrameSetText(TooltipTextFrame, description)
-						call BlzFrameSetSize(TooltipFrame, 0.29, GetTooltipSize(description))
+						call BlzFrameSetSize(TooltipFrame, 0.29, tooltipSize)
 						call BlzFrameSetVisible(TooltipFrame, true)
 					endif       
 				endif
@@ -339,6 +359,8 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 		// Cleanup
 		set u = null
 		set p = null
+		set itemStock = null
+		set frame = null
 	endfunction
 	
 	private function UpdateRoundStartGlobalIcons takes EventInfo eventInfo returns nothing
@@ -392,6 +414,7 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
         local integer selectedUnitPid = SelectedUnitPid[pid]
         local integer unitTypeId = 0
 		local PlayerStats ps
+		local string iconPath
 
         if selectedUnitPid == 27 then
             set selectedUnitPid = pid
@@ -399,15 +422,23 @@ library IconFrames initializer init requires TooltipFrame, ItemStock, Achievemen
 
 		set ps = PlayerStats.forPlayer(Player(selectedUnitPid))
 
-		if (GetLocalPlayer() == p) then
-			// Player ready status
-			if (ps != 0 and ps.isReady()) then
-				call BlzFrameSetTexture(ButtonId[40], GetIconPath("ReadyNoText"), 0, true)
-			else
-				call BlzFrameSetTexture(ButtonId[40], GetIconPath("NotReadyNoText"), 0, true)
-			endif
+		// Player ready status
+		if (ps != 0 and ps.isReady()) then
+			set iconPath = GetIconPath("ReadyNoText")
 
-			// Update the flashy ready status for the player
+			if (GetLocalPlayer() == p) then
+				call BlzFrameSetTexture(ButtonId[40], iconPath, 0, true)
+			endif
+		else
+			set iconPath = GetIconPath("NotReadyNoText")
+
+			if (GetLocalPlayer() == p) then
+				call BlzFrameSetTexture(ButtonId[40], iconPath, 0, true)
+			endif
+		endif
+
+		// Update the flashy ready status for the player
+		if (GetLocalPlayer() == p) then
 			call BlzFrameSetVisible(ButtonIndicatorParentId[40], PlayerIsAlwaysReady[selectedUnitPid])
 		endif
 

--- a/Trigger/06-UI/ReadyButton.j
+++ b/Trigger/06-UI/ReadyButton.j
@@ -73,7 +73,8 @@ library ReadyButton initializer init requires PlayerTracking, AllPlayersComplete
     endfunction
 
     function ReadyButtonVisibility takes boolean disable, integer pid, boolean isReady returns nothing
-        local string tex = ""
+        local string tex
+        local string iconPath
 
         if (IsPlayerInForce(Player(pid), DefeatedPlayers)) then
             set disable = true
@@ -86,14 +87,18 @@ library ReadyButton initializer init requires PlayerTracking, AllPlayersComplete
 
         if disable then
             set ReadyButtonDisabled[pid] = true
+            set iconPath = GetDisabledIconPath(tex)
+
             if GetLocalPlayer() == Player(pid) then
-                call BlzFrameSetTexture(ButtonId[5], GetDisabledIconPath(tex), 0, true)
+                call BlzFrameSetTexture(ButtonId[5], iconPath, 0, true)
                 call BlzFrameSetVisible(ButtonIndicatorParentId[5], PlayerIsAlwaysReady[pid])
             endif
         else
             set ReadyButtonDisabled[pid] = false
+            set iconPath = GetIconPath(tex)
+
             if GetLocalPlayer() == Player(pid) then
-                call BlzFrameSetTexture(ButtonId[5], GetIconPath(tex), 0, true)
+                call BlzFrameSetTexture(ButtonId[5], iconPath, 0, true)
                 call BlzFrameSetVisible(ButtonIndicatorParentId[5], PlayerIsAlwaysReady[pid])
             endif
         endif
@@ -164,6 +169,7 @@ library ReadyButton initializer init requires PlayerTracking, AllPlayersComplete
     function PlayerReadies takes player p, boolean isEndRound returns nothing
         local integer pid = GetPlayerId(p)
         local PlayerStats ps = PlayerStats.forPlayer(p)
+        local string message
 
         if (IsPlayerInForce(p, DefeatedPlayers)) then
             set PlayerIsAlwaysReady[pid] = false
@@ -191,7 +197,9 @@ library ReadyButton initializer init requires PlayerTracking, AllPlayersComplete
 
             //only show text to everyone once
             if not PlayerHasReadied[pid] then
-                call DisplayTimedTextToPlayer(GetLocalPlayer(), 0, 0, 10, GetPlayerNameColour(p) + " is ready. |c00fcff3b" + I2S(ReadyPlayerCount()) + "|r/|c000bff03" + I2S(PlayerCount) + "|r")
+                set message = GetPlayerNameColour(p) + " is ready. |c00fcff3b" + I2S(ReadyPlayerCount()) + "|r/|c000bff03" + I2S(PlayerCount) + "|r"
+
+                call DisplayTimedTextToPlayer(GetLocalPlayer(), 0, 0, 10, message)
             else
                 if ps.isReady() then
                     call DisplayTimedTextToPlayer(p, 0, 0, 10, GetPlayerNameColour(p) + " is ready. |c00fcff3b" + I2S(ReadyPlayerCount()) + "|r/|c000bff03" + I2S(PlayerCount) + "|r")

--- a/Trigger/06-UI/RewardsScreen.j
+++ b/Trigger/06-UI/RewardsScreen.j
@@ -125,10 +125,14 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
 
     // Add additional reward points to a player
     public function RewardPoints takes integer playerId, integer points returns nothing
+        local string pointsMessage
+
         set PlayerRewardPoints[playerId] = PlayerRewardPoints[playerId] + points
 
+        set pointsMessage = AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[playerId])
+
         if (GetLocalPlayer() == Player(playerId)) then	
-            call BlzFrameSetText(AvailablePointsFrame, AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[playerId])) 
+            call BlzFrameSetText(AvailablePointsFrame, pointsMessage) 
         endif
     endfunction
 
@@ -246,9 +250,11 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
         local real tooltipWidth = 0.32
         local string tooltipDescription
         local string tooltipName
+        local real tooltipSize
         local integer playerRewardIndex = 0
         local integer rewardCount = 0
         local integer primaryStat
+        local string pointsMessage
 
         if (BlzGetTriggerFrameEvent() == FRAMEEVENT_CONTROL_CLICK) then
             if (GetLocalPlayer() == triggerPlayer) then	
@@ -260,9 +266,9 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
             if (handleId == CloseHandleId) then
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetVisible(RewardsFrameHandle, false) 
-                    call PlayerStats.forPlayer(triggerPlayer).setHasRewardsOpen(false)
                 endif
 
+                call PlayerStats.forPlayer(triggerPlayer).setHasRewardsOpen(false)
             // Reset
             elseif (handleId == ResetHandleId) then
                 loop
@@ -280,17 +286,21 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
             
                 set PlayerRewardPoints[triggerPlayerId] = PlayerRewardPoints[triggerPlayerId] + rewardCount
 
+                set pointsMessage = AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[triggerPlayerId])
+
                 if (GetLocalPlayer() == triggerPlayer) then	
-                    call BlzFrameSetText(AvailablePointsFrame, AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[triggerPlayerId])) 
+                    call BlzFrameSetText(AvailablePointsFrame, pointsMessage) 
                 endif
             // Select reward
             elseif (PlayerRewardPoints[triggerPlayerId] > 0) then
                 set PlayerRewardPoints[triggerPlayerId] = PlayerRewardPoints[triggerPlayerId] - 1
                 set PlayerRewardSelection[(REWARD_BUFFER * triggerPlayerId) + rewardIndex] = PlayerRewardSelection[(REWARD_BUFFER * triggerPlayerId) + rewardIndex] + 1
 
+                set pointsMessage = AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[triggerPlayerId])
+
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetText(RewardSelectionCountFramehandles[rewardIndex], I2S(PlayerRewardSelection[(REWARD_BUFFER * triggerPlayerId) + rewardIndex])) 
-                    call BlzFrameSetText(AvailablePointsFrame, AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[triggerPlayerId])) 
+                    call BlzFrameSetText(AvailablePointsFrame, pointsMessage) 
 
                     if (PlayerRewardSelection[(REWARD_BUFFER * triggerPlayerId) + rewardIndex] >= 10) then
                         call BlzFrameSetSize(RewardSelectionCountParentFramehandles[rewardIndex], 0.03, 0.02)
@@ -340,11 +350,13 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
                 set tooltipDescription = tooltipDescription + "|n|nTotal bonus accumulated: " + R2S(PlayerTotalRewardValues[(REWARD_BUFFER * triggerPlayerId) + rewardIndex])
             endif
 
+            set tooltipSize = GetTooltipSize(tooltipDescription)
+
             if (GetLocalPlayer() == triggerPlayer) then	
                 call BlzFrameSetText(RewardsTooltipTitleFrame, tooltipName)
                 call BlzFrameSetText(RewardsTooltipTextFrame, tooltipDescription)
                 call BlzFrameSetPoint(RewardsTooltipFrame, FRAMEPOINT_TOP, currentFrameHandle, FRAMEPOINT_BOTTOM, 0, 0)
-                call BlzFrameSetSize(RewardsTooltipFrame, tooltipWidth, GetTooltipSize(tooltipDescription))
+                call BlzFrameSetSize(RewardsTooltipFrame, tooltipWidth, tooltipSize)
                 call BlzFrameSetVisible(RewardsTooltipFrame, true)
             endif
 
@@ -556,6 +568,7 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
         local integer pid = GetPlayerId(eventInfo.p)
         local unit playerHero
         local real rewardValue
+        local string pointsMessage
 
         // Don't do anything if this was the BR or the player is defeated
         if (IsFunBRRound or BrStarted or IsPlayerInForce(eventInfo.p, DefeatedPlayers) or (GameModeShort == true and RoundNumber == 25) or RoundNumber == 50) then
@@ -583,12 +596,15 @@ library RewardsScreen initializer init requires PlayerTracking, IconFrames, Util
                 endif
             endif
 
+            set pointsMessage = AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[pid])
+
             // Show the rewards screen
             if (GetLocalPlayer() == Player(pid)) then	
-                call BlzFrameSetText(AvailablePointsFrame, AVAILABLE_POINTS_COLOR + "Available Points: " + COLOR_END_TAG + I2S(PlayerRewardPoints[pid])) 
+                call BlzFrameSetText(AvailablePointsFrame, pointsMessage) 
                 call BlzFrameSetVisible(RewardsFrameHandle, true) 
-                call PlayerStats.forPlayer(Player(pid)).setHasRewardsOpen(true)
             endif
+
+            call PlayerStats.forPlayer(Player(pid)).setHasRewardsOpen(true)
 
             // Show the rewards icon
             call BlzFrameSetVisible(ButtonParentId[6], true)

--- a/Trigger/06-UI/Scoreboard/Scoreboard.j
+++ b/Trigger/06-UI/Scoreboard/Scoreboard.j
@@ -574,6 +574,7 @@ library Scoreboard initializer init requires PlayerTracking, HeroAbilityTable, I
         local real tooltipWidth = 0.29 // Default used by almost everything
         local string tooltipDescription
         local string tooltipName
+        local real tooltipSize
 
         if (BlzGetTriggerFrameEvent() == FRAMEEVENT_CONTROL_CLICK) then
             if (GetLocalPlayer() == triggerPlayer) then	
@@ -585,8 +586,9 @@ library Scoreboard initializer init requires PlayerTracking, HeroAbilityTable, I
             if (handleId == CloseHandleId) then
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetVisible(ScoreboardFrameHandle, false) 
-                    call PlayerStats.forPlayer(triggerPlayer).setHasScoreboardOpen(false)
                 endif
+
+                call PlayerStats.forPlayer(triggerPlayer).setHasScoreboardOpen(false)
 
             // Toggle selected player's hero if it exists and is alive
             elseif (columnIndex == PLAYER_HERO_INDEX and (not PlayerLeftGame[playerId]) and PlayerHeroes[playerId] != null and UnitAlive(PlayerHeroes[playerId])) then
@@ -617,11 +619,13 @@ library Scoreboard initializer init requires PlayerTracking, HeroAbilityTable, I
 
             // Show the tooltip information if valid
             if (tooltipName != "") then
+                set tooltipSize = GetTooltipSize(tooltipDescription)
+
                 if (GetLocalPlayer() == triggerPlayer) then	
                     call BlzFrameSetText(ScoreboardTooltipTitleFrame, tooltipName)
                     call BlzFrameSetText(ScoreboardTooltipTextFrame, tooltipDescription)
                     call BlzFrameSetPoint(ScoreboardTooltipFrame, FRAMEPOINT_TOP, currentFrameHandle, FRAMEPOINT_BOTTOM, 0, 0)
-                    call BlzFrameSetSize(ScoreboardTooltipFrame, tooltipWidth, GetTooltipSize(tooltipDescription))
+                    call BlzFrameSetSize(ScoreboardTooltipFrame, tooltipWidth, tooltipSize)
                     call BlzFrameSetVisible(ScoreboardTooltipFrame, true)
                 endif
             endif

--- a/Trigger/06-UI/Voting/VotingScreen.j
+++ b/Trigger/06-UI/Voting/VotingScreen.j
@@ -184,13 +184,14 @@ library VotingScreen initializer init requires IconFrames, VotingResults
     endfunction
 
     private function VotingMouseEventActions takes nothing returns nothing
-        local integer buttonType = GetButtonType(GetHandleId(BlzGetTriggerFrame()))
-		local integer index = GetIndex(buttonType, GetHandleId(BlzGetTriggerFrame()))
+        local framehandle frame = BlzGetTriggerFrame()
+        local integer buttonType = GetButtonType(GetHandleId(frame))
+		local integer index = GetIndex(buttonType, GetHandleId(frame))
         local PlayerVotes pv = PlayerVotes(GetPlayerId(GetTriggerPlayer()) + 1)
 
         if BlzGetTriggerFrameEvent() == FRAMEEVENT_CONTROL_CLICK then
             // Count how many people have actually voted. Can end the voting early if everyone votes
-            if SubmitHandleId == GetHandleId(BlzGetTriggerFrame()) then
+            if SubmitHandleId == GetHandleId(frame) then
                 if GetLocalPlayer() == GetTriggerPlayer() then
                     call BlzFrameSetVisible(MainVotingFrameHandle, false)
                 endif
@@ -204,11 +205,13 @@ library VotingScreen initializer init requires IconFrames, VotingResults
                     call DisplayTimedTextToPlayer(GetTriggerPlayer(), 0, 0, 5, "Please wait for other players to vote")
                 endif
 
+                set frame = null
+
                 return
             endif
 
             if GetLocalPlayer() == GetTriggerPlayer() then
-                call ReplaceSelectedButton(buttonType, index, BlzGetTriggerFrame())
+                call ReplaceSelectedButton(buttonType, index, frame)
             endif
 
             call SetButtonVote(pv, buttonType, index)
@@ -223,10 +226,12 @@ library VotingScreen initializer init requires IconFrames, VotingResults
                 call BlzFrameSetText(VoteDescriptionTextDisplay, "")
             endif
         elseif BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED then
-            call SetCheckboxVote(pv, 2, GetHandleId(BlzGetTriggerFrame()))
+            call SetCheckboxVote(pv, 2, GetHandleId(frame))
         elseif BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_UNCHECKED then
-            call SetCheckboxVote(pv, 1, GetHandleId(BlzGetTriggerFrame()))
+            call SetCheckboxVote(pv, 1, GetHandleId(frame))
         endif
+
+        set frame = null
     endfunction
 
     // Functions to get X,Y coordinates for a button

--- a/Trigger/07-Heroes/Passives/Letinant.j
+++ b/Trigger/07-Heroes/Passives/Letinant.j
@@ -1,42 +1,33 @@
 library Letinant initializer init requires HeroLvlTable
-
     globals
         Table LetinantStatBonus
     endglobals
 
-    function LetinantBonus takes unit u, integer levels returns nothing
-        local integer stat = 0
-        local integer i = 0
-        local integer bonus = 0
+    private function AddToStat takes unit u, integer bonus, integer stat returns nothing
+        if stat == 1 then
+            call SetHeroStr(u, GetHeroStr(u, false) + bonus, false)
+            call UpdateBonus(u, 0, bonus)
+        elseif stat == 2 then
+            call SetHeroAgi(u, GetHeroAgi(u, false) + bonus, false)
+            call UpdateBonus(u, 1, bonus)
+        else
+            call SetHeroInt(u, GetHeroInt(u, false) + bonus, false)
+            call UpdateBonus(u, 2, bonus)
+        endif
+    endfunction
 
-        set LetinantStatBonus[GetHandleId(u)] = 5 + (((GetHeroLevel(u) - ModuloInteger(GetHeroLevel(u), 10)) / 10))
-        set bonus = LetinantStatBonus[GetHandleId(u)]
+    function LetinantBonus takes unit u, integer levels returns nothing
+        local integer bonus = 5 + ((GetHeroLevel(u) - ModuloInteger(GetHeroLevel(u), 10)) / 10)
+        local integer i = 0
+        local integer stat
+
+        set LetinantStatBonus[GetHandleId(u)] = bonus
         call SetBonus(u, 3, bonus)
 
         loop
-            set stat = GetRandomInt(1,3)
-            if stat == 1 then
-                call SetHeroStr(u,GetHeroStr(u,false)+ bonus,false) 
-                call UpdateBonus(u, 0, bonus)
-            elseif stat == 2 then
-                call SetHeroAgi(u,GetHeroAgi(u,false)+ bonus,false)  
-                call UpdateBonus(u, 1, bonus) 
-            elseif stat == 3 then    
-                call SetHeroInt(u,GetHeroInt(u,false)+ bonus,false) 
-                call UpdateBonus(u, 2, bonus)  
-            endif
-            set stat = GetRandomInt(1,3)
-            if stat == 1 then
-                call SetHeroStr(u,GetHeroStr(u,false)+ bonus,false) 
-                call UpdateBonus(u, 0, bonus)
-            elseif stat == 2 then
-                call SetHeroAgi(u,GetHeroAgi(u,false)+ bonus,false)   
-                call UpdateBonus(u, 1, bonus)
-            elseif stat == 3 then    
-                call SetHeroInt(u,GetHeroInt(u,false)+ bonus,false)   
-                call UpdateBonus(u, 2, bonus)
-            endif
-            
+            call AddToStat(u, bonus, GetRandomInt(1, 3))
+            call AddToStat(u, bonus, GetRandomInt(1, 3))
+
             set i = i + 1
             exitwhen i >= levels
         endloop
@@ -45,4 +36,5 @@ library Letinant initializer init requires HeroLvlTable
     private function init takes nothing returns nothing
         set LetinantStatBonus = Table.create()
     endfunction
+
 endlibrary

--- a/Trigger/07-Heroes/Passives/Murloc.j
+++ b/Trigger/07-Heroes/Passives/Murloc.j
@@ -4,9 +4,9 @@ library Murloc initializer init requires CustomGameEvent
         local integer i1 = LoadInteger(HT, hid, 54021)
 
         if i1 != 0 then 
-            call SetHeroStr(eventInfo.hero, GetHeroStr(eventInfo.hero, false) - i1, false)
-            call SetHeroAgi(eventInfo.hero, GetHeroAgi(eventInfo.hero, false) - i1, false)
-            call SetHeroInt(eventInfo.hero, GetHeroInt(eventInfo.hero, false) - i1, false)
+            call AddUnitBonus(eventInfo.hero, BONUS_STRENGTH, 0 - i1)
+            call AddUnitBonus(eventInfo.hero, BONUS_AGILITY, 0 - i1)
+            call AddUnitBonus(eventInfo.hero, BONUS_INTELLIGENCE, 0 - i1)
             call SaveInteger(HT, hid, 54021, 0)
         endif
     endfunction

--- a/Trigger/08-Abilities/General/1-Multicast.j
+++ b/Trigger/08-Abilities/General/1-Multicast.j
@@ -1,90 +1,83 @@
 library MultiBonusCast requires RandomShit, AbilityData, CustomState
-
     function IsAbilityMulticastable takes integer abilId returns boolean
         return abilId != RESET_TIME_ABILITY_ID and abilId != DEATH_AND_DECAY_ABILITY_ID and abilId != SAND_OF_TIME_ABILITY_ID
     endfunction
 
     function CanMulticast takes unit caster, integer abilId returns boolean
-        return (GetUnitAbilityLevel(caster, MULTICAST_ABILITY_ID) > 0 or GetUnitTypeId(caster) == OGRE_MAGE_UNIT_ID or (UnitHasItemType(caster, 'I08X') and IsSpellElement(caster, abilId, Element_Fire) ) or GetUnitAbilityLevel(caster, CHEATER_MAGIC_ABILITY_ID) > 0) and IsAbilityMulticastable(abilId)
+        return (GetUnitAbilityLevel(caster, MULTICAST_ABILITY_ID) > 0 or GetUnitTypeId(caster) == OGRE_MAGE_UNIT_ID or (UnitHasItemType(caster, 'I08X') and IsSpellElement(caster, abilId, Element_Fire)) or GetUnitAbilityLevel(caster, CHEATER_MAGIC_ABILITY_ID) > 0) and IsAbilityMulticastable(abilId)
     endfunction
 
     function MultiBonusCast takes unit caster, unit target, integer abilId, integer abilOrder, location spellLoc returns nothing
-        local real targetX
-        local real targetY
-        local real multicastLvl = GetUnitAbilityLevel(caster,MULTICAST_ABILITY_ID)
+        local real targetX = 0
+        local real targetY = 0
         local integer orderType = 0
         local integer amount = 0
-        local real ogreMage1
-        local real ogreMage2
-
+        local real multicastLvl = GetUnitAbilityLevel(caster, MULTICAST_ABILITY_ID)
         local real luck = GetUnitCustomState(caster, BONUS_LUCK)
+        local real ogreMageChance
 
-        if target == null then
-            set orderType = 1
-            if spellLoc == null then
-                set orderType = 0
-                set targetX = GetUnitX(caster)
-                set targetY = GetUnitY(caster)
-            else
-                set orderType = 2
-                set targetX = GetLocationX(spellLoc)
-                set targetY = GetLocationY(spellLoc)
-            endif
-        else
-            set orderType = 1
+        // Determine target coordinates and order type
+        if target != null then
+            set orderType = Order_Target
             set targetX = GetUnitX(target)
             set targetY = GetUnitY(target)
+        elseif spellLoc != null then
+            set orderType = Order_Point
+            set targetX = GetLocationX(spellLoc)
+            set targetY = GetLocationY(spellLoc)
+        else
+            set orderType = Order_Instant
+            set targetX = GetUnitX(caster)
+            set targetY = GetUnitY(caster)
         endif
 
-        //Check if caster has multicast
-        if GetAbilityOrderType(abilId) == 0 then
+        // Check if ability is valid for casting
+        if GetAbilityOrderType(abilId) == 0 or not IsCastingAllowed(caster) then
             set caster = null
             set target = null
             return
         endif
 
-        if CheckIfCastAllowed(caster) == false then
-
-            //Cheater Magic
-            if GetUnitAbilityLevel(caster, CHEATER_MAGIC_BUFF_ID) > 0 then
-                set amount = 1
-
-                if GetRandomInt(1,100) < 2 * GetUnitAbilityLevel(caster, CHEATER_MAGIC_ABILITY_ID) then
-                    set amount = 2
-                endif
-            endif
-
-            //Blaze Staff
-            if UnitHasItemType(caster,'I08X') and IsSpellElement(caster, abilId, Element_Fire) then
+        // Cheater Magic bonus
+        if GetUnitAbilityLevel(caster, CHEATER_MAGIC_BUFF_ID) > 0 then
+            set amount = 1
+            if GetRandomInt(1, 100) < 2 * GetUnitAbilityLevel(caster, CHEATER_MAGIC_ABILITY_ID) then
                 set amount = 2
             endif
+        endif
 
-            //amounticast chances
-            if multicastLvl > 0 then
-                if GetRandomReal(0,100)  <=   (8.75 + 0.25 * multicastLvl)* luck then
-                    set amount = 2 + amount
-                elseif GetRandomReal(0,100)  <=  (13.6 + 0.4 * multicastLvl)* luck then
-                    set amount = 1 + amount
-                endif
-            endif
+        // Blaze Staff bonus
+        if UnitHasItemType(caster, 'I08X') and IsSpellElement(caster, abilId, Element_Fire) then
+            set amount = amount + 2
+        endif
 
-            //Ogre Mage multicast chances
-            if GetUnitTypeId(caster) == OGRE_MAGE_UNIT_ID then
-                set ogreMage1 = 15 + GetHeroLevel(caster) * 1.2
-                set ogreMage2 = ogreMage1 / 100 
-                set ogreMage1 = ogreMage1 - ogreMage2 * 100
-                
-                set amount = amount + R2I(ogreMage2)
-                
-                if GetRandomReal(1,100) <= ogreMage1 * luck then
-                    set amount = amount + 1
-                endif
-            endif
-            
-            if amount > 0 then
-                call CreateTextTagTimerColor( "Multicast +" + I2S(amount)+ "!",1,GetUnitX(GetTriggerUnit()),GetUnitY(GetTriggerUnit()),80,1,255,50,255)
-                call Multicast.create(caster, target, abilId, GetUnitAbilityLevel(caster, abilId), abilOrder, orderType, targetX, targetY, amount)
+        // Multicast chances
+        if multicastLvl > 0 then
+            if GetRandomReal(0, 100) <= (8.75 + 0.25 * multicastLvl) * luck then
+                set amount = amount + 2
+            elseif GetRandomReal(0, 100) <= (13.6 + 0.4 * multicastLvl) * luck then
+                set amount = amount + 1
             endif
         endif
+
+        // Ogre Mage multicast chances
+        if GetUnitTypeId(caster) == OGRE_MAGE_UNIT_ID then
+            set ogreMageChance = 15. + (GetHeroLevel(caster) * 1.2)
+            loop
+                exitwhen ogreMageChance < 100
+                set amount = amount + 1
+                set ogreMageChance = ogreMageChance - 100
+            endloop
+            if GetRandomReal(0, 100) <= ogreMageChance * luck then
+                set amount = amount + 1
+            endif
+        endif
+
+        // Trigger multicast if applicable
+        if amount > 0 then
+            call CreateTextTagTimerColor("Multicast +" + I2S(amount) + "!", 1, GetUnitX(caster), GetUnitY(caster), 80, 1, 255, 50, 255)
+            call Multicast.create(caster, target, abilId, GetUnitAbilityLevel(caster, abilId), abilOrder, orderType, targetX, targetY, amount)
+        endif
     endfunction
+
 endlibrary

--- a/Trigger/08-Abilities/General/Spell Effects.j
+++ b/Trigger/08-Abilities/General/Spell Effects.j
@@ -208,7 +208,7 @@ library SpellEffects initializer init requires MultiBonusCast, ChaosMagic, Urn, 
                     call DruidicFocusPhyspowerbonus(hero)
                 endif
             
-                if GetUnitTypeId(caster) != PRIEST_1_UNIT_ID and (not CheckIfCastAllowed(caster)) then
+                if GetUnitTypeId(caster) != PRIEST_1_UNIT_ID and IsCastingAllowed(caster) then
                     //call BJDebugMsg("caster: " + GetUnitName(caster))
                     call ElementStartAbility(caster, abilId)
 

--- a/Trigger/08-Abilities/Passive/ShadowStep.j
+++ b/Trigger/08-Abilities/Passive/ShadowStep.j
@@ -11,7 +11,7 @@ library ShadowStep initializer init requires AbilityCooldown, CustomGameEvent
         local real y = GetUnitY(u2) - 65 * SinBJ(GetUnitFacing(u1) + 180)
         local integer lvl = GetUnitAbilityLevel(u1, SHADOW_STEP_ABILITY_ID)
 
-        if lvl > 0 and (not CheckIfCastAllowed(u1)) and IsUnitEnemy(u2, GetOwningPlayer(u1)) and IsTerrainWalkable(x, y) then
+        if lvl > 0 and IsCastingAllowed(u1) and IsUnitEnemy(u2, GetOwningPlayer(u1)) and IsTerrainWalkable(x, y) then
             set dist =  CalculateDistance(GetUnitX(u1), GetUnitX(u2), GetUnitY(u1), GetUnitY(u2))
 
             if GetWidgetLife(u2) > 0.025 and u2 != null and dist <= 900 and dist >= 125 and (BlzGetUnitAbilityCooldownRemaining(u1, SHADOW_STEP_ABILITY_ID) <= 0 or UnitHasForm(u1, FORM_SHADOW)) then

--- a/Trigger/09-Items/18-Rune/5-RuneItem/07-RuneOfFire.j
+++ b/Trigger/09-Items/18-Rune/5-RuneItem/07-RuneOfFire.j
@@ -8,9 +8,7 @@ library FireRune requires RandomShit
         local unit u = GLOB_RUNE_U
         local real power = GLOB_RUNE_POWER 
 
-
-
-        call DummyInstantCast1(u,GetUnitX(u),GetUnitY(u),'A02V',"fanofknives",  R2I(RuneOfFire_base_dmg * power), ConvertAbilityRealLevelField('Ocl1') )
+        call DummyInstantCast1(u,GetUnitX(u),GetUnitY(u),'A02V',"fanofknives",  R2I(RuneOfFire_base_dmg * power), ConvertAbilityRealLevelField('Ocl1'), 4)
 
         set u = null
         return false

--- a/Trigger/15-triggers/init-parsed/GameInit.j
+++ b/Trigger/15-triggers/init-parsed/GameInit.j
@@ -210,11 +210,9 @@ library GameInit initializer init requires GroupUtils
         call SetCameraBounds(-5376.0 + GetCameraMargin(CAMERA_MARGIN_LEFT), -5632.0 + GetCameraMargin(CAMERA_MARGIN_BOTTOM), 5376.0 - GetCameraMargin(CAMERA_MARGIN_RIGHT), 5120.0 - GetCameraMargin(CAMERA_MARGIN_TOP), -5376.0 + GetCameraMargin(CAMERA_MARGIN_LEFT), 5120.0 - GetCameraMargin(CAMERA_MARGIN_TOP), 5376.0 - GetCameraMargin(CAMERA_MARGIN_RIGHT), -5632.0 + GetCameraMargin(CAMERA_MARGIN_BOTTOM))
         call SetDayNightModels("Environment\\DNC\\DNCLordaeron\\DNCLordaeronTerrain\\DNCLordaeronTerrain.mdl", "Environment\\DNC\\DNCLordaeron\\DNCLordaeronUnit\\DNCLordaeronUnit.mdl")
         call NewSoundEnvironment("Default")
-        call SetAmbientDaySound("SunkenRuinsDay")
-        call SetAmbientNightSound("SunkenRuinsNight")
+        call SetAmbientDaySound("LordaeronSummerDay")
+        call SetAmbientNightSound("LordaeronSummerNight")
         call SetMapMusic("Music", true, 0)
-
-        call AddWeatherEffectSaveLast(GetPlayableMapRect(), 'SNhs')
     endfunction
 
     private function InitializeSounds takes nothing returns nothing

--- a/Trigger/15-triggers/init-parsed/Mechanics/Abilities/DisableAbilities.j
+++ b/Trigger/15-triggers/init-parsed/Mechanics/Abilities/DisableAbilities.j
@@ -9,7 +9,7 @@ library DisableAbilities initializer init requires RandomShit, DummySpell
             return
         endif
 
-        if CheckIfCastAllowed(u) or ((p != Player(8) and p != Player(11)) and CurrentlyFighting[GetPlayerId(p)] == false) then
+        if (not IsCastingAllowed(u)) or ((p != Player(8) and p != Player(11)) and CurrentlyFighting[GetPlayerId(p)] == false) then
             call IssueImmediateOrder(u, "stop")
             //call BJDebugMsg(GetUnitName(u) +  "disable abilities stop")
         endif

--- a/Trigger/15-triggers/init-parsed/Mechanics/PVP/Battle Royal/BattleRoyaleHelper.j
+++ b/Trigger/15-triggers/init-parsed/Mechanics/PVP/Battle Royal/BattleRoyaleHelper.j
@@ -584,7 +584,7 @@ library BattleRoyaleHelper initializer init requires ItemStock, RandomShit, Star
 
         set WaitingForBattleRoyal = true
         
-        call SetUpItemStocks(GetPlayersAll())
+        call SetUpItemStocks(GetValidPlayerForce())
         
         call TimerStart(BattleRoyalTimer, BattleRoyalWaitTime, false, function FinalizeBattleRoyaleSetup)
     endfunction


### PR DESCRIPTION
General
 - Removed Snow in Reforged
 - Leavers no longer get an Item Buddy
 - Some fixes for potential desync causes
 - Updated Item Buddy explanation
 - Slightly more space for abilities in the next round creep description

Heroes
 - Fixed Yeti Infinite Strength bug
 - Fixed Thunder Witch passive incorrect target count
 - Fixed Crypt Lord passive incorrect Locust amount
 - Fixed Sorcerer passive causing crashes
 - Fixed Demon Hunter Passive not working on physical damage
 - Fixed Ogre Mage passive

Abilities
 - Bash and Destruction now have [onhit] tags. (They were already [onhit])
 - Arcane Assault: Removed mentions of Multishot and Cleave in shop description
 - Added a 0.33 second cooldown to Fire Force

Items
 - Magic Amulet now deals damage to 10 units instead of 11
 - Fixed Glory Attack Cooldown Limit